### PR TITLE
Added support for Punching Mirror at the "get fights" step of runPvP

### DIFF
--- a/kolmafia/scripts/pLoop.ash
+++ b/kolmafia/scripts/pLoop.ash
@@ -108,7 +108,7 @@ void runPvP() {
     if (item_amount($item[School of Hard Knocks Diploma]) > 0 && !get_property("_hardKnocksDiplomaUsed").to_boolean()) {
         cli_execute("use School of Hard Knocks Diploma");
     }
-    if (item_amount($item[punching mirror] > 0)) {
+    if (item_amount($item[punching mirror] > 0) && !get_property("_punchingMirrorUsed").to_boolean()) {
         use(1, $item[punching mirror]);
     }
 

--- a/kolmafia/scripts/pLoop.ash
+++ b/kolmafia/scripts/pLoop.ash
@@ -108,6 +108,9 @@ void runPvP() {
     if (item_amount($item[School of Hard Knocks Diploma]) > 0 && !get_property("_hardKnocksDiplomaUsed").to_boolean()) {
         cli_execute("use School of Hard Knocks Diploma");
     }
+    if (item_amount($item[punching mirror] > 0)) {
+        use(1, $item[punching mirror]);
+    }
 
     //uberpvp
     cli_execute("PVP_MAB");

--- a/kolmafia/scripts/pLoop.ash
+++ b/kolmafia/scripts/pLoop.ash
@@ -108,8 +108,16 @@ void runPvP() {
     if (item_amount($item[School of Hard Knocks Diploma]) > 0 && !get_property("_hardKnocksDiplomaUsed").to_boolean()) {
         cli_execute("use School of Hard Knocks Diploma");
     }
-    if (item_amount($item[punching mirror] > 0) && !get_property("_punchingMirrorUsed").to_boolean()) {
-        use(1, $item[punching mirror]);
+	
+    item mirror = $item[punching mirror];
+    if (item_amount(mirror) > 0 && !get_property("_punchingMirrorUsed").to_boolean()) {
+        use(1, mirror);
+    }
+	
+    item fire = $item[CSA fire-starting kit];
+    if (item_amount(fire) > 0 && !get_property("_fireStartingKitUsed").to_boolean()) {
+        set_property("choiceAdventure595", "1");
+        use(1, fire);
     }
 
     //uberpvp


### PR DESCRIPTION
This will need to be fixed once mafia improves support for the mirror. Currently mafia "removes" the mirror from its tracking of your inventory after you use it, but if you refresh the inventory it can be "used" again. I'm submitting a PR to them to add the same sort of tracking they do for the hard knocks diploma.